### PR TITLE
[INTER-3024] Set default is instant values when enabled

### DIFF
--- a/.github/workflows/deploy-all-psh-stores.yaml
+++ b/.github/workflows/deploy-all-psh-stores.yaml
@@ -42,4 +42,5 @@ jobs:
                 git add timestamp
                 git commit -m "Update store"
                 platform push --no-wait
+                cd ..
               done

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -21,6 +21,7 @@ class Config
     private const PATH_IS_INSTANT_ON_PRODUCT_PAGE_ENABLED = 'checkout/bold_checkout_paypal/is_instant_product';
     private const PATH_IS_INSTANT_ENABLED_FOR = 'checkout/bold_checkout_paypal/instant_for';
     private const PATH_PAYPAL_FLOW_ID = 'checkout/bold_checkout_paypal/flow_id';
+    private const DEFAULT_VALUE_IS_INSTANT = 'simple,virtual,downloadable,grouped,configurable,bundle,giftcard';
 
     /**
      * @var ScopeConfigInterface
@@ -152,15 +153,20 @@ class Config
      */
     public function isProductPageInstantCheckoutEnabledForType(int $websiteId, string $productType): bool
     {
-        return in_array(
-            $productType,
-            explode(
-                ',',
-                $this->configManagement->getValue(
-                    self::PATH_IS_INSTANT_ENABLED_FOR,
-                    $websiteId
-                )
-            )
+        $options = $this->configManagement->getValue(
+            self::PATH_IS_INSTANT_ENABLED_FOR,
+            $websiteId
+        );
+
+        return in_array($productType, explode(',', $options ?? ''));
+    }
+
+    public function setIsInstantForDefault(int $websiteId): void {
+        $this->configWriter->save(
+            self::PATH_IS_INSTANT_ENABLED_FOR,
+            self::DEFAULT_VALUE_IS_INSTANT,
+            $websiteId ? ScopeInterface::SCOPE_WEBSITES : ScopeConfigInterface::SCOPE_TYPE_DEFAULT,
+            $websiteId
         );
     }
 }

--- a/Model/PaypalFlow.php
+++ b/Model/PaypalFlow.php
@@ -43,6 +43,9 @@ class PaypalFlow
     public function toggle(int $websiteId): bool
     {
         $status = $this->config->getIsPaypalFlowEnabled($websiteId);
+        if (!$status) {
+            $this->config->setIsInstantForDefault($websiteId);
+        }
 
         return $status ? $this->disable($websiteId) : $this->enable($websiteId);
     }
@@ -60,11 +63,9 @@ class PaypalFlow
             $url = sprintf(self::FLOW_DISABLE_URL, $flowId);
             $response = $this->client->delete($websiteId, $url, []);
             if ($response->getErrors()) {
-
                 return false;
             }
         } catch (\Exception $exception) {
-
             return false;
         }
         $this->config->setIsPaypalFlowEnabled($websiteId, false);


### PR DESCRIPTION
- Set default value for is instant product type when the paypal flow is re enabled.
- Prevent error on product page when Paypal instant checkout is enabled and no product type is selected.
- Added `cd ..` to github workflow to prevent continual nesting of projects. 